### PR TITLE
Add console.log support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ failOnConsole({
 ## But I have some expected console errors/warning
 
 If a `console.error()` is expected, then you should assert for it:
+
 ```ts
 test('should log an error', () => {
   jest.spyOn(console, 'error').mockImplementation()
@@ -67,6 +68,13 @@ Use this to make a test fail when an error is logged.
 
 - Type: `boolean`
 - Default: `true`
+
+### shouldFailOnLog
+
+Use this to make a test fail when a message is logged.
+
+- Type: `boolean`
+- Default: `false`
 
 ### silenceMessage
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,11 +4,13 @@ export type InitOptions = {
    * If true is returned, the message will not show in the console
    * and the test won't fail.
    */
-  silenceMessage?: (message: string, methodName: 'warn' | 'error') => boolean
+  silenceMessage?: (message: string, methodName: 'warn' | 'error' | 'log') => boolean
   /** defaults to true */
   shouldFailOnWarn?: boolean
   /** defaults to true */
   shouldFailOnError?: boolean
+  /** defaults to false */
+  shouldFailOnLog?: boolean
 }
 declare function init(options?: InitOptions): void
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 const util = require('util')
 const chalk = require('chalk')
 
-const init = ({ silenceMessage, shouldFailOnWarn = true, shouldFailOnError = true } = {}) => {
+const init = ({
+  silenceMessage,
+  shouldFailOnWarn = true,
+  shouldFailOnError = true,
+  shouldFailOnLog = false,
+} = {}) => {
   const patchConsoleMethod = (methodName, unexpectedConsoleCallStacks) => {
     const newMethod = (format, ...args) => {
       const message = util.format(format, ...args)
@@ -53,7 +58,7 @@ const init = ({ silenceMessage, shouldFailOnWarn = true, shouldFailOnError = tru
 
       const message =
         `Expected test not to call ${chalk.bold(`console.${methodName}()`)}.\n\n` +
-        `If the warning is expected, test for it explicitly by mocking it out using ${chalk.bold(
+        `If the ${methodName} is expected, test for it explicitly by mocking it out using ${chalk.bold(
           'jest.spyOn'
         )}(console, '${methodName}') and test that the warning occurs.`
 
@@ -63,13 +68,18 @@ const init = ({ silenceMessage, shouldFailOnWarn = true, shouldFailOnError = tru
 
   const unexpectedErrorCallStacks = []
   const unexpectedWarnCallStacks = []
+  const unexpectedLogCallStacks = []
 
-  let errorMethod, warnMethod
+  let errorMethod, warnMethod, logMethod
+
   if (shouldFailOnError) {
     errorMethod = patchConsoleMethod('error', unexpectedErrorCallStacks)
   }
   if (shouldFailOnWarn) {
     warnMethod = patchConsoleMethod('warn', unexpectedWarnCallStacks)
+  }
+  if (shouldFailOnLog) {
+    logMethod = patchConsoleMethod('log', unexpectedLogCallStacks)
   }
 
   const flushAllUnexpectedConsoleCalls = () => {
@@ -79,13 +89,18 @@ const init = ({ silenceMessage, shouldFailOnWarn = true, shouldFailOnError = tru
     if (shouldFailOnWarn) {
       flushUnexpectedConsoleCalls(warnMethod, 'warn', unexpectedWarnCallStacks)
     }
+    if (shouldFailOnLog) {
+      flushUnexpectedConsoleCalls(logMethod, 'log', unexpectedLogCallStacks)
+    }
     unexpectedErrorCallStacks.length = 0
     unexpectedWarnCallStacks.length = 0
+    unexpectedLogCallStacks.length = 0
   }
 
   const resetAllUnexpectedConsoleCalls = () => {
     unexpectedErrorCallStacks.length = 0
     unexpectedWarnCallStacks.length = 0
+    unexpectedLogCallStacks.length = 0
   }
 
   beforeEach(resetAllUnexpectedConsoleCalls)


### PR DESCRIPTION
Thanks for this package! It's a great way to prevent the "Broken windows theory" in a project.

One thing that I am missing is the ability to fail the tests if `console.log` messages are present in the test output. I think it would be useful to add a flag to fail on logs just as it currently fails on errors and warnings. What do you think?

As authored currently, the failure is defaulted to `true` but I'd be happy to have it at the opt-in level to keep existing users happy.