### PR TITLE
Fail tests on console assertion failure

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,8 @@ declare namespace init {
     shouldFailOnError?: boolean
     /** defaults to false */
     shouldFailOnLog?: boolean
+    /** defaults to false */
+    shouldFailOnAssert?: boolean
     /**
      * This function lets you define a custom error message. The methodName is the method
      * that caused the error, bold is a function that lets you bold subsets of your message.

--- a/index.js
+++ b/index.js
@@ -56,10 +56,6 @@ const init = ({
       }
     }
 
-    const newLoggingMethod = (format, ...args) => {
-      captureMessage(format, ...args)
-    }
-
     const newAssertMethod = (assertion, format, ...args) => {
       if (!assertion) {
         return
@@ -68,7 +64,7 @@ const init = ({
       captureMessage(format, ...args)
     }
 
-    const newMethod = methodName === 'assert' ? newAssertMethod : newLoggingMethod
+    const newMethod = methodName === 'assert' ? newAssertMethod : captureMessage
 
     let originalMethod = console[methodName]
 


### PR DESCRIPTION
Currently, you can error when one of three console methods are called: log, warn, and error. For libraries that are using `console.assert` to do validation (such as I'm using for parameter validation in [this project](https://github.com/doug-wade/itscalledsoccer/blob/master/src/index.js#L66) ), a failed console assertion is an indication of a problem of some kind. Here, I add a new method stub to console to intercept calls to assert, and fail the test only if the assertion fails. This is behind a parameter which defaults to false, so upgrading clients shouldn't be disrupted, and we shouldn't have to bump the major version.