### PR TITLE
feature(#16): Add Support for console.debug & console.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # jest-fail-on-console
 
-Utility to make jest tests fail when console.error() or console.warn() are used
+Utility to make jest tests fail when `console.error()`, `console.warn()`, etc. are used
 
 [![version][version-badge]][package] [![Monthly downloads][npmstats-badge]][npmstats] [![MIT License][license-badge]][license] [![PRs Welcome][prs-badge]][prs]
 
 ## What problem is this solving?
 
-Jest doesn't fail the tests when there is a `console.error`. In large codebase, we can end up with the test output overloaded by a lot of errors and warnings.
-To prevent this, we want to fail each test that is logging an error or a warning to the console. We also want to conserve a clear output of the original error.
+Jest doesn't fail the tests when there is a `console.error`. In large codebase, we can end up with the test output overloaded by a lot of errors, warnings, etc..
+To prevent this, we want to fail each test that is logging to the console. We also want to conserve a clear output of the original error.
 
 This is what this utility is doing.
+
 ![image](https://user-images.githubusercontent.com/2678610/104045400-cbe05b80-51de-11eb-820c-b96190bbff7f.png)
 
 ## Install
@@ -55,33 +56,72 @@ test('should log an error', () => {
 
 You can pass an object with options to the function:
 
-### shouldFailOnWarn
+### errorMessage
 
-Use this to make a test fail when a warning is logged.
+Use this if you want to override the default error message of this library.
 
-- Type: `boolean`
-- Default: `true`
+```ts
+// signature
+type errorMessage = (
+  methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn',
+  bold: (string) => string
+) => string
+```
 
-### shouldFailOnError
+### shouldFailOnAssert
 
-Use this to make a test fail when an error is logged.
-
-- Type: `boolean`
-- Default: `true`
-
-### shouldFailOnLog
-
-Use this to make a test fail when a message is logged.
+Use this to make a test fail when a `console.assert()` is logged.
 
 - Type: `boolean`
 - Default: `false`
 
+### shouldFailOnDebug
+
+Use this to make a test fail when a `console.debug()` is logged.
+
+- Type: `boolean`
+- Default: `false`
+
+### shouldFailOnError
+
+Use this to make a test fail when a `console.error()` is logged.
+
+- Type: `boolean`
+- Default: `true`
+
+### shouldFailOnInfo
+
+Use this to make a test fail when a `console.info()` is logged.
+
+- Type: `boolean`
+- Default: `false`
+
+### shouldFailOnLog
+
+Use this to make a test fail when a `console.log()` is logged.
+
+- Type: `boolean`
+- Default: `false`
+
+### shouldFailOnWarn
+
+Use this to make a test fail when a `console.warn()` is logged.
+
+- Type: `boolean`
+- Default: `true`
+
 ### silenceMessage
 
-- Signature: `(message: string, methodName: 'warn' | 'error') => boolean`
+```ts
+// signature
+type silenceMessage = (
+  message: string,
+  methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn'
+) => boolean
+```
 
-This function is called for every console warn/error.
-If true is returned, the message will not show in the console and the test won't fail.
+This function is called for every console method supported by this utility.
+If `true` is returned, the message will not show in the console and the test won't fail.
 
 Example:
 
@@ -95,12 +135,6 @@ failOnConsole({
   },
 })
 ```
-
-### errorMessage
-
-Use this if you want to override the default error message of this library.
-
-- Signature: `(methodName: string, bold: (string) => string) => string`
 
 ## License
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,25 +1,42 @@
 declare namespace init {
   type InitOptions = {
     /**
-     * This function is called for every console warn/error.
-     * If true is returned, the message will not show in the console
-     * and the test won't fail.
-     */
-    silenceMessage?: (message: string, methodName: 'warn' | 'error' | 'log') => boolean
-    /** defaults to true */
-    shouldFailOnWarn?: boolean
-    /** defaults to true */
-    shouldFailOnError?: boolean
-    /** defaults to false */
-    shouldFailOnLog?: boolean
-    /** defaults to false */
-    shouldFailOnAssert?: boolean
-    /**
      * This function lets you define a custom error message. The methodName is the method
      * that caused the error, bold is a function that lets you bold subsets of your message.
      * example: (methodName, bold) => `console.${methodName} is not ${bold('allowed')}`
      */
-    errorMessage?: (methodName: string, bold: (string) => string) => string
+    errorMessage?: (
+      methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn',
+      bold: (string) => string
+    ) => string
+
+    /** @default false */
+    shouldFailOnAssert?: boolean
+
+    /** @default false */
+    shouldFailOnDebug?: boolean
+
+    /** @default true */
+    shouldFailOnError?: boolean
+
+    /** @default false */
+    shouldFailOnInfo?: boolean
+
+    /** @default false */
+    shouldFailOnLog?: boolean
+
+    /** @default true */
+    shouldFailOnWarn?: boolean
+
+    /**
+     * This function is called for every console warn/error.
+     * If true is returned, the message will not show in the console
+     * and the test won't fail.
+     */
+    silenceMessage?: (
+      message: string,
+      methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn'
+    ) => boolean
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -8,12 +8,14 @@ const defaultErrorMessage = (methodName, bold) =>
   )}(console, '${methodName}').mockImplementation() and test that the warning occurs.`
 
 const init = ({
-  silenceMessage,
-  shouldFailOnWarn = true,
-  shouldFailOnError = true,
-  shouldFailOnLog = false,
-  shouldFailOnAssert = false,
   errorMessage = defaultErrorMessage,
+  shouldFailOnAssert = false,
+  shouldFailOnDebug = false,
+  shouldFailOnError = true,
+  shouldFailOnInfo = false,
+  shouldFailOnLog = false,
+  shouldFailOnWarn = true,
+  silenceMessage,
 } = {}) => {
   const flushUnexpectedConsoleCalls = (methodName, unexpectedConsoleCallStacks) => {
     if (unexpectedConsoleCallStacks.length > 0) {
@@ -79,18 +81,12 @@ const init = ({
     })
   }
 
-  if (shouldFailOnError) {
-    patchConsoleMethod('error')
-  }
-  if (shouldFailOnWarn) {
-    patchConsoleMethod('warn')
-  }
-  if (shouldFailOnLog) {
-    patchConsoleMethod('log')
-  }
-  if (shouldFailOnAssert) {
-    patchConsoleMethod('assert')
-  }
+  if (shouldFailOnAssert) patchConsoleMethod('assert')
+  if (shouldFailOnDebug) patchConsoleMethod('debug')
+  if (shouldFailOnError) patchConsoleMethod('error')
+  if (shouldFailOnInfo) patchConsoleMethod('info')
+  if (shouldFailOnLog) patchConsoleMethod('log')
+  if (shouldFailOnWarn) patchConsoleMethod('warn')
 }
 
 module.exports = init


### PR DESCRIPTION
- add support for `console.debug` (Closes #16)
- add support for `console.info` (Closes #16)
- improve types
  - fix `methodName` string union not containing all supported methods
  - sort alphabetically
  - add spacing for readability
  - use TSDoc `@default`
- improve readme
  - document undocumented options
  - formatting
  - fix implications that `error`/`warn` are the only supported methods
  - use TS to document function signatures