### PR TITLE
Param to skip test names when specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ failOnConsole({
 })
 ```
 
+### skipTestNames
+
+Use this if you want to ignore checks introduced by this library for specific test names.
+
+```ts
+failOnConsole({
+  skipTestNames: ['TEST_NAME'],
+})
+```
+
 ## License
 
 [MIT](https://github.com/ValentinH/jest-fail-on-console/blob/master/LICENSE)

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,11 @@ declare namespace init {
       message: string,
       methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn'
     ) => boolean
+
+    /**
+     * This parameter lets you define a list of test names to skip console checks for.
+     */
+    skipTestNames?: []
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ declare namespace init {
     /**
      * This parameter lets you define a list of test names to skip console checks for.
      */
-    skipTestNames?: []
+    skipTestNames?: string[]
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const init = ({
   shouldFailOnInfo = false,
   shouldFailOnLog = false,
   shouldFailOnWarn = true,
+  skipTestNames = [],
   silenceMessage,
 } = {}) => {
   const flushUnexpectedConsoleCalls = (methodName, unexpectedConsoleCallStacks) => {
@@ -71,11 +72,13 @@ const init = ({
     let originalMethod = console[methodName]
 
     beforeEach(() => {
+      if (skipTestNames.includes(expect.getState().currentTestName)) return
       console[methodName] = newMethod // eslint-disable-line no-console
       unexpectedConsoleCallStacks.length = 0
     })
 
     afterEach(() => {
+      if (skipTestNames.includes(expect.getState().currentTestName)) return
       flushUnexpectedConsoleCalls(methodName, unexpectedConsoleCallStacks)
       console[methodName] = originalMethod
     })


### PR DESCRIPTION
Allows specification of a `skipTestNames` parameter to skip test names from erroring out