### PR TITLE
Support for callback function to skip tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,26 @@ failOnConsole({
 })
 ```
 
+### skipTests
+
+Use this if you want to ignore checks introduced by this library for specific tests determined by
+the return of the callback function. Return `false` if you do not want to skip console checks for
+the specific test and return `true` if you would like to skip it.
+
+```ts
+const ignoreList = [/.*components\/SomeComponent.test.tsx/]
+
+failOnConsole({
+  skipTests: ({ testPath }) => {
+    for (const pathExp of ignoreList) {
+      const result = pathExp.test(testPath)
+      if (result) return true
+    }
+    return false
+  },
+})
+```
+
 ## License
 
 [MIT](https://github.com/ValentinH/jest-fail-on-console/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ failOnConsole({
 })
 ```
 
-### skipTests
+### skipTest
 
 Use this if you want to ignore checks introduced by this library for specific tests determined by
 the return of the callback function. Return `false` if you do not want to skip console checks for
@@ -156,7 +156,7 @@ the specific test and return `true` if you would like to skip it.
 const ignoreList = [/.*components\/SomeComponent.test.tsx/]
 
 failOnConsole({
-  skipTests: ({ testPath }) => {
+  skipTest: ({ testPath }) => {
     for (const pathExp of ignoreList) {
       const result = pathExp.test(testPath)
       if (result) return true

--- a/README.md
+++ b/README.md
@@ -136,16 +136,6 @@ failOnConsole({
 })
 ```
 
-### skipTestNames
-
-Use this if you want to ignore checks introduced by this library for specific test names.
-
-```ts
-failOnConsole({
-  skipTestNames: ['TEST_NAME'],
-})
-```
-
 ### skipTest
 
 Use this if you want to ignore checks introduced by this library for specific tests determined by

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,11 +39,6 @@ declare namespace init {
     ) => boolean
 
     /**
-     * This parameter lets you define a list of test names to skip console checks for.
-     */
-    skipTestNames?: string[]
-
-    /**
      * This function is called for every test setup and teardown to determine if the test should
      * skip console checks from this package or not.
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ declare namespace init {
      * This function is called for every test setup and teardown to determine if the test should
      * skip console checks from this package or not.
      */
-    skipTests?: (currentTestName: string, currentTestPath: string) => boolean
+    skipTests?: ({ testName: string, testPath: string }) => boolean
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ declare namespace init {
      * This function is called for every test setup and teardown to determine if the test should
      * skip console checks from this package or not.
      */
-    skipTests?: ({ testName: string, testPath: string }) => boolean
+    skipTest?: ({ testName: string, testPath: string }) => boolean
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,12 @@ declare namespace init {
      * This parameter lets you define a list of test names to skip console checks for.
      */
     skipTestNames?: string[]
+
+    /**
+     * This function is called for every test setup and teardown to determine if the test should
+     * skip console checks from this package or not.
+     */
+    skipTests?: (currentTestName: string, currentTestPath: string) => boolean
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ const init = ({
   shouldFailOnInfo = false,
   shouldFailOnLog = false,
   shouldFailOnWarn = true,
-  skipTestNames = [],
   skipTest,
   silenceMessage,
 } = {}) => {
@@ -77,7 +76,6 @@ const init = ({
       const testName = currentTestState.currentTestName
       const testPath = currentTestState.testPath
 
-      if (skipTestNames.includes(testName)) return true
       if (skipTest && skipTest({ testName, testPath })) return true
 
       return false

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const init = ({
   shouldFailOnLog = false,
   shouldFailOnWarn = true,
   skipTestNames = [],
+  skipTests,
   silenceMessage,
 } = {}) => {
   const flushUnexpectedConsoleCalls = (methodName, unexpectedConsoleCallStacks) => {
@@ -71,14 +72,22 @@ const init = ({
 
     let originalMethod = console[methodName]
 
+    const currentTestState = expect.getState()
+    const currentTestName = currentTestState.currentTestName
+    const currentTestPath = currentTestState.testPath
+
     beforeEach(() => {
-      if (skipTestNames.includes(expect.getState().currentTestName)) return
+      if (skipTestNames.includes(currentTestName)) return
+      if (skipTests && skipTests(currentTestName, currentTestPath)) return
+
       console[methodName] = newMethod // eslint-disable-line no-console
       unexpectedConsoleCallStacks.length = 0
     })
 
     afterEach(() => {
-      if (skipTestNames.includes(expect.getState().currentTestName)) return
+      if (skipTestNames.includes(currentTestName)) return
+      if (skipTests && skipTests(currentTestName, currentTestPath)) return
+
       flushUnexpectedConsoleCalls(methodName, unexpectedConsoleCallStacks)
       console[methodName] = originalMethod
     })

--- a/index.js
+++ b/index.js
@@ -72,21 +72,27 @@ const init = ({
 
     let originalMethod = console[methodName]
 
-    const currentTestState = expect.getState()
-    const testName = currentTestState.currentTestName
-    const testPath = currentTestState.testPath
+    const canSkipTest = () => {
+      const currentTestState = expect.getState()
+      const testName = currentTestState.currentTestName
+      const testPath = currentTestState.testPath
+
+      if (skipTestNames.includes(testName)) return true
+      if (skipTests && skipTests({ testName, testPath })) return true
+
+      return false
+    }
+    const shouldSkipTest = canSkipTest()
 
     beforeEach(() => {
-      if (skipTestNames.includes(testName)) return
-      if (skipTests && skipTests({ testName, testPath })) return
+      if (shouldSkipTest) return
 
       console[methodName] = newMethod // eslint-disable-line no-console
       unexpectedConsoleCallStacks.length = 0
     })
 
     afterEach(() => {
-      if (skipTestNames.includes(testName)) return
-      if (skipTests && skipTests({ testName, testPath })) return
+      if (shouldSkipTest) return
 
       flushUnexpectedConsoleCalls(methodName, unexpectedConsoleCallStacks)
       console[methodName] = originalMethod

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const init = ({
   shouldFailOnLog = false,
   shouldFailOnWarn = true,
   skipTestNames = [],
-  skipTests,
+  skipTest,
   silenceMessage,
 } = {}) => {
   const flushUnexpectedConsoleCalls = (methodName, unexpectedConsoleCallStacks) => {
@@ -78,7 +78,7 @@ const init = ({
       const testPath = currentTestState.testPath
 
       if (skipTestNames.includes(testName)) return true
-      if (skipTests && skipTests({ testName, testPath })) return true
+      if (skipTest && skipTest({ testName, testPath })) return true
 
       return false
     }

--- a/index.js
+++ b/index.js
@@ -73,20 +73,20 @@ const init = ({
     let originalMethod = console[methodName]
 
     const currentTestState = expect.getState()
-    const currentTestName = currentTestState.currentTestName
-    const currentTestPath = currentTestState.testPath
+    const testName = currentTestState.currentTestName
+    const testPath = currentTestState.testPath
 
     beforeEach(() => {
-      if (skipTestNames.includes(currentTestName)) return
-      if (skipTests && skipTests(currentTestName, currentTestPath)) return
+      if (skipTestNames.includes(testName)) return
+      if (skipTests && skipTests({ testName, testPath })) return
 
       console[methodName] = newMethod // eslint-disable-line no-console
       unexpectedConsoleCallStacks.length = 0
     })
 
     afterEach(() => {
-      if (skipTestNames.includes(currentTestName)) return
-      if (skipTests && skipTests(currentTestName, currentTestPath)) return
+      if (skipTestNames.includes(testName)) return
+      if (skipTests && skipTests({ testName, testPath })) return
 
       flushUnexpectedConsoleCalls(methodName, unexpectedConsoleCallStacks)
       console[methodName] = originalMethod

--- a/tests/fixtures/error-skip-test/index.js
+++ b/tests/fixtures/error-skip-test/index.js
@@ -1,0 +1,1 @@
+module.exports = () => console.error('test message')

--- a/tests/fixtures/error-skip-test/index.test.js
+++ b/tests/fixtures/error-skip-test/index.test.js
@@ -1,0 +1,7 @@
+const consoleError = require('.')
+
+describe('console.error skip test', () => {
+  it('does not throw', () => {
+    expect(consoleError).not.toThrow()
+  })
+})

--- a/tests/fixtures/error-skip-test/jest.config.js
+++ b/tests/fixtures/error-skip-test/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}

--- a/tests/fixtures/error-skip-test/jest.setup.js
+++ b/tests/fixtures/error-skip-test/jest.setup.js
@@ -1,0 +1,6 @@
+const failOnConsole = require('../../..')
+
+failOnConsole({
+  shouldFailOnError: true,
+  skipTest: ({ testPath }) => /.*tests\/fixtures\/error-skip-test\/index.test.js/.test(testPath),
+})

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -29,6 +29,12 @@ describe('jest-fail-on-console', () => {
     expect(stderr).toEqual(expect.stringContaining(passString('error-disabled')))
   })
 
+  it.only('does not error when console.error() is called and skip test returns true', async () => {
+    const { stderr } = await runFixture('error-skip-test')
+
+    expect(stderr).toEqual(expect.stringContaining(passString('error-skip-test')))
+  })
+
   it('errors when console.assert() is called with a failing assertion', async () => {
     const { stderr } = await runFixture('assert-failure')
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -29,7 +29,7 @@ describe('jest-fail-on-console', () => {
     expect(stderr).toEqual(expect.stringContaining(passString('error-disabled')))
   })
 
-  it.only('does not error when console.error() is called and skip test returns true', async () => {
+  it('does not error when console.error() is called and skip test returns true', async () => {
     const { stderr } = await runFixture('error-skip-test')
 
     expect(stderr).toEqual(expect.stringContaining(passString('error-skip-test')))


### PR DESCRIPTION
Addition of a `skipTest` callback function param which provides a higher degree of customization to determine if a test should be skipped or not.

> this could potentially make the `skipTestNames` param redundant earlier but I'd leave it there for backwards compatibility just in case someone has already started using it 👍 