### PR TITLE
ValentinH/jest-fail-on-console#30: Respect Jest --noStackTrace flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,9 @@ const init = ({
         const stackLines = stack.split('\n')
         return (
           `${chalk.red(message)}\n` +
-          `${stackLines
-            .map((line, index) => {
+          `${process.argv.indexOf("--noStackTrace") !== -1
+            ? chalk.white(stackLines.slice(-1))
+            : stackLines.map( (line, index) => {
               if (index === stackLines.length - 1) {
                 return chalk.white(line)
               }


### PR DESCRIPTION
This is a trivial implementation of the feature referenced in issue ValentinH/jest-fail-on-console#30 .
I'm not sure how to test it though.

What do you think ?