### PR TITLE
Add support for passing group context to `silenceMessage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Use this to make a test fail when a `console.warn()` is logged.
 // signature
 type silenceMessage = (
   message: string,
-  methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn'
+  methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn',
+  context: { group: string, groups: string[] }
 ) => boolean
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,8 @@ declare namespace init {
      */
     silenceMessage?: (
       message: string,
-      methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn'
+      methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn',
+      context: { group: string, groups: string[] }
     ) => boolean
 
     /**

--- a/tests/fixtures/silence-by-group/index.js
+++ b/tests/fixtures/silence-by-group/index.js
@@ -1,0 +1,6 @@
+module.exports = () => {
+  console.group('a group')
+  console.log('one')
+  console.log('two')
+  console.groupEnd()
+}

--- a/tests/fixtures/silence-by-group/index.test.js
+++ b/tests/fixtures/silence-by-group/index.test.js
@@ -1,0 +1,7 @@
+const consoleGroup = require('.')
+
+describe('console.group silence message', () => {
+  it('does not throw', () => {
+    expect(consoleGroup).not.toThrow()
+  })
+})

--- a/tests/fixtures/silence-by-group/jest.config.js
+++ b/tests/fixtures/silence-by-group/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}

--- a/tests/fixtures/silence-by-group/jest.setup.js
+++ b/tests/fixtures/silence-by-group/jest.setup.js
@@ -1,0 +1,7 @@
+const failOnConsole = require('../../..')
+
+failOnConsole({
+  shouldFailOnLog: true,
+  shouldFailOnError: false,
+  silenceMessage: (msg, fn, context) => /^a group$/.test(context.group),
+})

--- a/tests/fixtures/silence-by-message/index.js
+++ b/tests/fixtures/silence-by-message/index.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  console.log('my message')
+}

--- a/tests/fixtures/silence-by-message/index.test.js
+++ b/tests/fixtures/silence-by-message/index.test.js
@@ -1,0 +1,7 @@
+const consoleLog = require('.')
+
+describe('console.log silence message by message', () => {
+  it('does not throw', () => {
+    expect(consoleLog).not.toThrow()
+  })
+})

--- a/tests/fixtures/silence-by-message/jest.config.js
+++ b/tests/fixtures/silence-by-message/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}

--- a/tests/fixtures/silence-by-message/jest.setup.js
+++ b/tests/fixtures/silence-by-message/jest.setup.js
@@ -1,0 +1,6 @@
+const failOnConsole = require('../../..')
+
+failOnConsole({
+  shouldFailOnLog: true,
+  silenceMessage: (msg) => /^my message$/.test(msg),
+})

--- a/tests/fixtures/silence-by-method/index.js
+++ b/tests/fixtures/silence-by-method/index.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  console.warn('my message')
+}

--- a/tests/fixtures/silence-by-method/index.test.js
+++ b/tests/fixtures/silence-by-method/index.test.js
@@ -1,0 +1,7 @@
+const consoleWarn = require('.')
+
+describe('console.warn silence message by method', () => {
+  it('does not throw', () => {
+    expect(consoleWarn).not.toThrow()
+  })
+})

--- a/tests/fixtures/silence-by-method/jest.config.js
+++ b/tests/fixtures/silence-by-method/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}

--- a/tests/fixtures/silence-by-method/jest.setup.js
+++ b/tests/fixtures/silence-by-method/jest.setup.js
@@ -1,0 +1,6 @@
+const failOnConsole = require('../../..')
+
+failOnConsole({
+  shouldFailOnWarn: true,
+  silenceMessage: (msg, method) => method === 'warn',
+})

--- a/tests/fixtures/silence-by-nested-group/index.js
+++ b/tests/fixtures/silence-by-nested-group/index.js
@@ -1,0 +1,7 @@
+module.exports = () => {
+  console.group('group one')
+  console.group('group two')
+  console.log('msg')
+  console.groupEnd()
+  console.groupEnd()
+}

--- a/tests/fixtures/silence-by-nested-group/index.test.js
+++ b/tests/fixtures/silence-by-nested-group/index.test.js
@@ -1,0 +1,7 @@
+const consoleGroup = require('.')
+
+describe('console.group silence message', () => {
+  it('does not throw', () => {
+    expect(consoleGroup).not.toThrow()
+  })
+})

--- a/tests/fixtures/silence-by-nested-group/jest.config.js
+++ b/tests/fixtures/silence-by-nested-group/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}

--- a/tests/fixtures/silence-by-nested-group/jest.setup.js
+++ b/tests/fixtures/silence-by-nested-group/jest.setup.js
@@ -1,0 +1,7 @@
+const failOnConsole = require('../../..')
+
+failOnConsole({
+  shouldFailOnLog: true,
+  shouldFailOnError: false,
+  silenceMessage: (msg, fn, context) => context.groups.includes('group one'),
+})

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -52,4 +52,28 @@ describe('jest-fail-on-console', () => {
 
     expect(stderr).toEqual(expect.stringContaining(passString('assert-success')))
   })
+
+  it('does not error if message is silenced with `silenceMessage`', async () => {
+    const { stderr } = await runFixture('silence-by-message')
+
+    expect(stderr).toEqual(expect.stringContaining(passString('silence-by-message')))
+  })
+
+  it('does not error if message is silenced with `silenceMessage` based on console method', async () => {
+    const { stderr } = await runFixture('silence-by-method')
+
+    expect(stderr).toEqual(expect.stringContaining(passString('silence-by-method')))
+  })
+
+  it('does not error if message is silenced with `silenceMessage` based on group context', async () => {
+    const { stderr } = await runFixture('silence-by-group')
+
+    expect(stderr).toEqual(expect.stringContaining(passString('silence-by-group')))
+  })
+
+  it('does not error if message is silenced with `silenceMessage` based on nested group context', async () => {
+    const { stderr } = await runFixture('silence-by-nested-group')
+
+    expect(stderr).toEqual(expect.stringContaining(passString('silence-by-nested-group')))
+  })
 })


### PR DESCRIPTION
If a message is contained within a `console.group` or `console.groupCollapsed` call then track this context and provide to implementations of `silenceMessage`.

Because groups can be recursively nested, track both the parent group and the full group stack.