### PR TITLE
Include group context on failure output

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const init = ({
       // Don't throw yet though b'c it might be accidentally caught and suppressed.
       const { stack } = new Error()
       if (stack) {
-        unexpectedConsoleCallStacks.push([stack.substr(stack.indexOf('\n') + 1), message])
+        unexpectedConsoleCallStacks.push([stack.substr(stack.indexOf('\n') + 1), [...groups, message].join('\n')])
       }
     }
 


### PR DESCRIPTION
If there is a call to `console.group` around a `log|warn|error` then it is being swallowed and so when tests fail the output of `console.group` is not emitted to the console.

Include any group context in the `flushUnexpectedConsoleCalls` output so it can be debugged.