### PR TITLE
refactor: ➖ remove `chalk` as dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 const util = require('util')
 
 const chalk = {
-  red: (str) => `\u001b[31m${str}\u001b[0m`,
-  gray: (str) => `\u001b[90m${str}\u001b[0m`,
-  white: (str) => `\u001b[37m${str}\u001b[0m`,
-  bold: (str) => `\u001b[1m${str}\u001b[22m`
+  red: (str) => `\u001B[31m${str}\u001B[39m`,
+  gray: (str) => `\u001B[90m${str}\u001B[39m`,
+  white: (str) => `\u001B[37m${str}\u001B[39m`,
+  bold: (str) => `\u001B[1m${str}\u001B[22m`,
 }
 
 const defaultErrorMessage = (methodName, bold) =>
-  `Expected test not to call ${(`console.${methodName}()`)}.\n\n` +
+  `Expected test not to call ${bold(`console.${methodName}()`)}.\n\n` +
   `If the ${methodName} is expected, test for it explicitly by mocking it out using ${bold(
     'jest.spyOn'
   )}(console, '${methodName}').mockImplementation() and test that the warning occurs.`
@@ -46,7 +46,7 @@ const init = ({
       throw new Error(`${message}\n\n${messages.join('\n\n')}`)
     }
   }
-  const groups = [];
+  const groups = []
 
   const patchConsoleMethod = (methodName) => {
     const unexpectedConsoleCallStacks = []
@@ -54,7 +54,10 @@ const init = ({
     const captureMessage = (format, ...args) => {
       const message = util.format(format, ...args)
 
-      if (silenceMessage && silenceMessage(message, methodName, { group: groups[groups.length - 1], groups })) {
+      if (
+        silenceMessage &&
+        silenceMessage(message, methodName, { group: groups[groups.length - 1], groups })
+      ) {
         return
       }
 
@@ -63,7 +66,10 @@ const init = ({
       // Don't throw yet though b'c it might be accidentally caught and suppressed.
       const { stack } = new Error()
       if (stack) {
-        unexpectedConsoleCallStacks.push([stack.substr(stack.indexOf('\n') + 1), [...groups, message].join('\n')])
+        unexpectedConsoleCallStacks.push([
+          stack.substr(stack.indexOf('\n') + 1),
+          [...groups, message].join('\n'),
+        ])
       }
     }
 
@@ -103,10 +109,10 @@ const init = ({
 
       return false
     }
-    let shouldSkipTest;
+    let shouldSkipTest
 
     beforeEach(() => {
-      shouldSkipTest = canSkipTest();
+      shouldSkipTest = canSkipTest()
       if (shouldSkipTest) return
 
       console[methodName] = newMethod // eslint-disable-line no-console

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 const util = require('util')
-const chalk = require('chalk')
+
+const chalk = {
+  red: (str) => `\u001b[31m${str}\u001b[0m`,
+  gray: (str) => `\u001b[90m${str}\u001b[0m`,
+  white: (str) => `\u001b[37m${str}\u001b[0m`,
+  bold: (str) => `\u001b[1m${str}\u001b[0m`
+};
 
 const defaultErrorMessage = (methodName, bold) =>
   `Expected test not to call ${bold(`console.${methodName}()`)}.\n\n` +

--- a/index.js
+++ b/index.js
@@ -4,11 +4,11 @@ const chalk = {
   red: (str) => `\u001b[31m${str}\u001b[0m`,
   gray: (str) => `\u001b[90m${str}\u001b[0m`,
   white: (str) => `\u001b[37m${str}\u001b[0m`,
-  bold: (str) => `\u001b[1m${str}\u001b[0m`
-};
+  bold: (str) => `\u001b[1m${str}\u001b[22m`
+}
 
 const defaultErrorMessage = (methodName, bold) =>
-  `Expected test not to call ${bold(`console.${methodName}()`)}.\n\n` +
+  `Expected test not to call ${(`console.${methodName}()`)}.\n\n` +
   `If the ${methodName} is expected, test for it explicitly by mocking it out using ${bold(
     'jest.spyOn'
   )}(console, '${methodName}').mockImplementation() and test that the warning occurs.`

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "test": "jest tests/index.test.js",
     "type-check": "tsc --noEmit index.d.ts"
   },
-  "dependencies": {
-    "chalk": "^4.1.0"
-  },
   "devDependencies": {
     "jest": "^27.5.1",
     "np": "^7.2.0",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -20,7 +20,7 @@ describe('jest-fail-on-console', () => {
   it('errors when console.error() is called', async () => {
     const { stderr } = await runFixture('error')
 
-    expect(stderr).toEqual(expect.stringContaining('Expected test not to call console.error().'))
+    expect(stderr).toEqual(expect.stringMatching(/Expected test not to call .*console.error().*/))
   })
 
   it('does not error when console.error() is called but shouldFailOnError is false', async () => {
@@ -44,7 +44,7 @@ describe('jest-fail-on-console', () => {
   it('errors when console.assert() is called with a failing assertion', async () => {
     const { stderr } = await runFixture('assert-failure')
 
-    expect(stderr).toEqual(expect.stringContaining('Expected test not to call console.assert().'))
+    expect(stderr).toEqual(expect.stringMatching(/Expected test not to call .*console.assert().*/))
   })
 
   it('does not error when console.assert() is called with a passing assertion', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,9 +1635,9 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -2613,7 +2613,7 @@ jest-worker@^27.5.1:
 
 jest@^27.5.1:
   version "27.5.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-27.5.1.tgz#dadf33ba70a779be7a6fc33015843b51494f63fc"
+  resolved "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz"
   integrity sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==
   dependencies:
     "@jest/core" "^27.5.1"
@@ -4048,7 +4048,7 @@ typedarray-to-buffer@^3.1.5:
 
 typescript@^4.8.2:
   version "4.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz"
   integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 unique-string@^2.0.0:


### PR DESCRIPTION
fixes: #43

Some docs: https://stackoverflow.com/questions/4842424/list-of-ansi-color-escape-sequences

Tested on Linux & Mac
Haven't tested on **Windows**

## Simple test
![image](https://github.com/ValentinH/jest-fail-on-console/assets/8749624/8dfbc009-a342-4c88-8f59-78a3917a0505)
