### PR TITLE
add configuration flag to immediately print from original console method

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ failOnConsole({
 })
 ```
 
+### shouldPrintMessage
+
+Use this to print the message immediately when called not awaiting the test to finish. This is useful to show the message if there are
+other or earlier test failures which will result in the fail on console error to be hidden by jest.
+
+- Type: `boolean`
+- Default: `false`
+
 ## License
 
 [MIT](https://github.com/ValentinH/jest-fail-on-console/blob/master/LICENSE)

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,9 @@ declare namespace init {
       methodName: ConsoleMethodName,
       context: { group: string; groups: string[] }
     ) => boolean
+
+    /** @default false */
+    shouldPrintMessage?: boolean
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const init = ({
   skipTest,
   silenceMessage,
   allowMessage,
+  shouldPrintMessage = false,
 } = {}) => {
   const flushUnexpectedConsoleCalls = (methodName, unexpectedConsoleCallStacks) => {
     if (unexpectedConsoleCallStacks.length > 0) {
@@ -70,6 +71,10 @@ const init = ({
       ) {
         originalMethod(format, ...args)
         return
+      }
+
+      if (shouldPrintMessage) {
+        originalMethod(format, ...args)
       }
 
       // Capture the call stack now so we can warn about it later.

--- a/tests/fixtures/print-message-with-other-failure/index.js
+++ b/tests/fixtures/print-message-with-other-failure/index.js
@@ -1,0 +1,4 @@
+module.exports = () => {
+  console.error('my error message that I do not control');
+  throw new Error('some other error');
+}

--- a/tests/fixtures/print-message-with-other-failure/index.test.js
+++ b/tests/fixtures/print-message-with-other-failure/index.test.js
@@ -1,0 +1,7 @@
+const consoleError = require('.')
+
+describe('print message flag with other test failure', () => {
+  it('does not throw', () => {
+    expect(consoleError).not.toThrow()
+  })
+})

--- a/tests/fixtures/print-message-with-other-failure/jest.config.js
+++ b/tests/fixtures/print-message-with-other-failure/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}

--- a/tests/fixtures/print-message-with-other-failure/jest.setup.js
+++ b/tests/fixtures/print-message-with-other-failure/jest.setup.js
@@ -1,0 +1,6 @@
+const failOnConsole = require('../../..')
+
+failOnConsole({
+  shouldFailOnError: true,
+  shouldPrintMessage: true,
+})

--- a/tests/fixtures/print-message/index.js
+++ b/tests/fixtures/print-message/index.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  console.error('my error message that I do not control')
+}

--- a/tests/fixtures/print-message/index.test.js
+++ b/tests/fixtures/print-message/index.test.js
@@ -1,0 +1,7 @@
+const consoleError = require('.')
+
+describe('print message flag', () => {
+  it('does not throw', () => {
+    expect(consoleError).not.toThrow()
+  })
+})

--- a/tests/fixtures/print-message/jest.config.js
+++ b/tests/fixtures/print-message/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}

--- a/tests/fixtures/print-message/jest.setup.js
+++ b/tests/fixtures/print-message/jest.setup.js
@@ -1,0 +1,6 @@
+const failOnConsole = require('../../..')
+
+failOnConsole({
+  shouldFailOnError: true,
+  shouldPrintMessage: true,
+})

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,4 +1,3 @@
-const fs = require('fs').promises
 const { exec } = require('child_process')
 
 const fixturesDirectory = 'tests/fixtures'
@@ -7,7 +6,7 @@ const runFixture = async (fixtureName) => {
   const configFilePath = `./${fixturesDirectory}/${fixtureName}/jest.config.js`
   const cmd = `./node_modules/.bin/jest ${testFilePath} --config ${configFilePath}`
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     exec(cmd, (error, stdout, stderr) => {
       resolve({ stdout, stderr })
     })
@@ -84,5 +83,21 @@ describe('jest-fail-on-console', () => {
     expect(stdout).toContain('my error message that I do not control');
 
     expect(stderr).toEqual(expect.stringContaining(passString('allow-message')))
+  })
+
+  it('prints the message to the console immediately even though fail on error is enabled', async () => {
+    const { stderr, stdout } = await runFixture('print-message')
+
+    expect(stdout).toContain('console.error');
+    expect(stdout).toContain('my error message that I do not control');
+
+    expect(stderr).toEqual(expect.stringMatching(/Expected test not to call .*console.error().*/));
+  })
+
+  it('prints the message to the console even though there is another reason the test failed', async () => {
+    const { stdout } = await runFixture('print-message-with-other-failure')
+
+    expect(stdout).toContain('console.error');
+    expect(stdout).toContain('my error message that I do not control');
   })
 })


### PR DESCRIPTION
See: https://github.com/ValentinH/jest-fail-on-console/issues/45

When there are other test failures jest swallows the console logs. In some cases e.g. when there is a log indicating why the test failed it is more time consuming to debug and find the reason as the log is not shown.

This PR introduces a flag which allows to show the console logs even though fail on console is enabled.
