### PR TITLE
Before runs flush out and report console calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,12 @@ const init = ({
     }
     let shouldSkipTest
 
+    beforeAll(() => {
+      flushUnexpectedConsoleCalls(methodName, unexpectedConsoleCallStacks)
+    })
+
+    console[methodName] = newMethod
+
     beforeEach(() => {
       shouldSkipTest = canSkipTest()
       if (shouldSkipTest) return

--- a/tests/fixtures/error-before-beforeEach/index.test.js
+++ b/tests/fixtures/error-before-beforeEach/index.test.js
@@ -1,0 +1,6 @@
+describe('console.error', () => {
+  it('does not throw', () => {
+    // Expected to be empty as we want to ensure the test works with a call outside of tests
+    // and not something that happens during testing.
+  })
+})

--- a/tests/fixtures/error-before-beforeEach/jest.config.js
+++ b/tests/fixtures/error-before-beforeEach/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}

--- a/tests/fixtures/error-before-beforeEach/jest.setup.js
+++ b/tests/fixtures/error-before-beforeEach/jest.setup.js
@@ -1,0 +1,5 @@
+const failOnConsole = require('../../..')
+
+failOnConsole()
+
+console.error('console error message out in the wild')

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -100,4 +100,11 @@ describe('jest-fail-on-console', () => {
     expect(stdout).toContain('console.error');
     expect(stdout).toContain('my error message that I do not control');
   })
+
+  it('errors when console.error() called before testing has begun', async () => {
+    const { stderr } = await runFixture('error-before-beforeEach')
+
+    expect(stderr).toContain('console.error');
+    expect(stderr).toContain('console error message out in the wild');
+  })
 })


### PR DESCRIPTION
This solves the issue where a console call happens after jest-fail-on-console has been setup but before test runs begin.

The current implementation would reset `unexpectedConsoleCallStacks` before every test, meaning that any `console.*` calls before would be considered a pass.

This change makes it so that `flushUnexpectedConsoleCalls` is called before testing has began.